### PR TITLE
Update ZaparooEsp32.ino

### DIFF
--- a/ZaparooEsp32/ZaparooEsp32.ino
+++ b/ZaparooEsp32/ZaparooEsp32.ino
@@ -41,7 +41,7 @@ ZaparooLaunchApi ZapClient;
 ZaparooScanner* tokenScanner = NULL;
 
 //globals
-String ZAP_URL = "ws://<replace>:7497/api/v0.1";
+String ZAP_URL = "ws://<replace>:7497" + String(ZaparooLaunchApi::wsPath);
 ZaparooToken* token = NULL;
 bool inserted = false;
 bool isPN532 = false;


### PR DESCRIPTION
Pull the path for the websocket directly from the library. That way as versions change, only one place needs to be updated among any potential projects.