### PR TITLE
Update to support the default esp web file server

### DIFF
--- a/ZaparooEsp32/ZaparooEsp32.ino
+++ b/ZaparooEsp32/ZaparooEsp32.ino
@@ -32,7 +32,7 @@ MFRC522 mfrc522(SS_PIN, RST_PIN);
 
 //Common Setup
 AudioOutputI2S* out;
-ESPWebFileManager fileManager;
+ESPWebFileManager* fileManager;
 Preferences preferences;
 AsyncWebServer server(80);
 AsyncWebSocket ws1("/ws");
@@ -401,7 +401,6 @@ void handleWebSocketMessage(void* arg, uint8_t* data, size_t len) {
       notifyClients("Saving UIDExtdRec Data", "log");
       JsonDocument data = root["data"];
       feedback.saveUidMapping(data);
-      //saveUIDExtdRec(root["data"]);
   } else if (command == "wifi") {
     setPref_Str("wifiSSID", root["data"]["ssid"].as<String>());
     setPref_Str("wifiPass", root["data"]["password"].as<String>());
@@ -525,15 +524,13 @@ void setup() {
 
   if (feedback.sdCardEnabled) {
     Serial.println("SD CARD MODE");
-    fileManager.initFileSystem(ESPWebFileManager::FS_SD_CARD, true);
-    fileManager.setServer(&server);
+    fileManager = new ESPWebFileManager(FS_SD, true);
   } else {
     Serial.println("LITTLEFS MODE");
-    fileManager.initFileSystem(ESPWebFileManager::FS_LITTLEFS, true);
-    fileManager.setServer(&server);
+    fileManager = new ESPWebFileManager(FS_LITTLEFS, true);
   }
-
-  
+  fileManager->setServer(&server);
+  fileManager->begin();
 }
 
 void loop() {


### PR DESCRIPTION
Since we no longer are using iframes, the original version of https://github.com/jobitjoseph/ESPWebFileManager can be used. Check the library documentation for all the required libraries. I just did a full delete and rebuild to confirm setup. Fixed some of the links and removed anything that did not need to be explicitly installed.